### PR TITLE
Remove subsidy rights

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -18,7 +18,7 @@
     RewriteRule ^beta/binet/([0-9]+)/show/?$ ./beta/index.php?controller=binet&action=show&binet=$1&%{QUERY_STRING} [L,NC,QSA]
     RewriteRule ^beta/binet/([0-9]+)/edit/?$ ./beta/index.php?controller=binet&action=edit&binet=$1&%{QUERY_STRING} [L,NC,QSA]
     RewriteRule ^beta/binet/([0-9]+)/update/?$ ./beta/index.php?controller=binet&action=update&binet=$1&%{QUERY_STRING} [L,NC,QSA]
-    RewriteRule ^beta/binet/([0-9]+)/set_subsidy_provider/?$ ./beta/index.php?controller=binet&action=set_subsidy_provider&binet=$1&%{QUERY_STRING} [L,NC,QSA]
+    RewriteRule ^beta/binet/([0-9]+)/switch_subsidy_provider/?$ ./beta/index.php?controller=binet&action=switch_subsidy_provider&binet=$1&%{QUERY_STRING} [L,NC,QSA]
     RewriteRule ^beta/binet/([0-9]+)/change_term/?$ ./beta/index.php?controller=binet&action=change_term&binet=$1&%{QUERY_STRING} [L,NC,QSA]
     RewriteRule ^beta/binet/([0-9]+)/power_transfer/?$ ./beta/index.php?controller=binet&action=power_transfer&binet=$1&%{QUERY_STRING} [L,NC,QSA]
     RewriteRule ^beta/binet/([0-9]+)/reactivate/?$ ./beta/index.php?controller=binet&action=reactivate&binet=$1&%{QUERY_STRING} [L,NC,QSA]

--- a/htdocs/beta/controller/binet.php
+++ b/htdocs/beta/controller/binet.php
@@ -10,15 +10,15 @@
     header_if(is_empty($current_term), 403);
   }
 
-  before_action("check_csrf_get", array("delete", "set_subsidy_provider", "deactivate", "power_transfer"));
+  before_action("check_csrf_get", array("delete", "switch_subsidy_provider", "deactivate", "power_transfer"));
   before_action(
     "check_entry",
-    array("edit", "update", "set_subsidy_provider", "show", "change_term", "reactivate", "deactivate", "power_transfer"),
+    array("edit", "update", "switch_subsidy_provider", "show", "change_term", "reactivate", "deactivate", "power_transfer"),
     array("model_name" => "binet")
   );
   before_action("check_is_activated", array("power_transfer", "deactivate"));
   before_action("check_is_deactivated", array("reactivate"));
-  before_action("current_kessier", array("new", "create", "power_transfer", "change_term", "deactivate", "reactivate", "set_subsidy_provider", "admin"));
+  before_action("current_kessier", array("new", "create", "power_transfer", "change_term", "deactivate", "reactivate", "switch_subsidy_provider", "admin"));
   before_action("check_editing_rights", array("edit", "update"));
   before_action("create_form", array("new", "create", "edit", "update", "change_term", "reactivate"), "binet");
   before_action("check_form", array("create", "update", "reactivate"), "binet");
@@ -49,9 +49,15 @@
     redirect_to_action("show");
     break;
 
-  case "set_subsidy_provider":
-    set_subsidy_provider($binet["id"]);
-    $_SESSION["notice"][] = "Le binet ".pretty_binet($binet["id"])." est devenu un binet subventionneur.";
+  case "switch_subsidy_provider":
+    // TODO add email
+    if (select_binet($binet["id"], array("subsidy_provider"))["subsidy_provider"]) {
+      unset_subsidy_provider($binet["id"]);
+      $_SESSION["notice"][] = "Le binet ".pretty_binet($binet["id"])." n'est à présent plus un binet subventionneur.";
+    } else {
+      set_subsidy_provider($binet["id"]);
+      $_SESSION["notice"][] = "Le binet ".pretty_binet($binet["id"])." est devenu un binet subventionneur.";
+    }
     redirect_to_action("show");
     break;
 

--- a/htdocs/beta/global/routes.php
+++ b/htdocs/beta/global/routes.php
@@ -121,7 +121,7 @@
       write_path_rule("home/login", true_path("login", "home"), "[NC,QSA]");
     }
     write_controller_rules(array("controller" => "home", "except" => array("new", "create", "show", "edit", "update", "delete"), "action_on_collection" => array("login", "logout", "welcome", "chose_identity", "bug_report")));
-    write_controller_rules(array("controller" => "binet", "except" => array("delete"), "action_on_member" => array("set_subsidy_provider", "change_term", "power_transfer", "reactivate", "deactivate")));
+    write_controller_rules(array("controller" => "binet", "except" => array("delete"), "action_on_member" => array("switch_subsidy_provider", "change_term", "power_transfer", "reactivate", "deactivate")));
     write_controller_rules(array("controller" => "operation", "except" => array("delete"), "action_on_member" => array("validate", "reject")));
     write_controller_rules(array("controller" => "tag", "except" => array("edit", "update", "delete")));
     write_controller_rules(array("controller" => "wave", "except" => array("new", "create", "edit", "update", "delete", "show")));

--- a/htdocs/beta/model/binet.php
+++ b/htdocs/beta/model/binet.php
@@ -75,6 +75,16 @@
     );
   }
 
+  function unset_subsidy_provider($binet) {
+    update_entry(
+      "binet",
+      array("subsidy_provider"),
+      array(),
+      $binet,
+      array("subsidy_provider" => 0)
+    );
+  }
+
   /*
   @param int $binet id of the binet , int(11) NOT NULL in table 'binet'
 

--- a/htdocs/beta/view/binet/show.php
+++ b/htdocs/beta/view/binet/show.php
@@ -17,8 +17,10 @@
         echo button(path("edit", "binet", $binet["id"]), "Modifier le binet", "edit", "orange");
       }
       if (is_current_kessier()) {
-        if ($binet["subsidy_provider"] == 0) {
-          echo button(path("set_subsidy_provider", "binet", $binet["id"], "", array(), true), "Ajouter les droits de subventionneur", "money", "blue");
+        if ($binet["subsidy_provider"]) {
+          echo button(path("switch_subsidy_provider", "binet", $binet["id"], "", array(), true), "Retirer les droits de subventionneur", "money", "red");
+        } else {
+          echo button(path("switch_subsidy_provider", "binet", $binet["id"], "", array(), true), "Ajouter les droits de subventionneur", "money", "blue");
         }
         echo button(path("change_term", "binet", $binet["id"]), is_empty($binet["current_term"]) ? "Réactiver le binet" : "Faire la passation", "forward", "green");
       }

--- a/htdocs/beta/view/layout/sidebar.php
+++ b/htdocs/beta/view/layout/sidebar.php
@@ -40,7 +40,8 @@
         $_GET["controller"] == "request"
       );
       // If subsidy provider
-      if (select_binet($binet, array("subsidy_provider"))["subsidy_provider"] == 1) {
+      $sidebar_waves = select_waves(array("binet" => $binet, "term" => $term));
+      if (!is_empty($sidebar_waves)) {
         ?>
         <li class="divider"></li>
         <?php


### PR DESCRIPTION
On peut merger

Permet de retirer les droits de subventionneur à un binet.
Si un binet subventionneur a été subventionneur mais ne l’est plus, on peut quand même voir ses vagues de subventions passées dans la sidebar.
/!\ il faut faire l’url_rewriting
