### PR TITLE
Navigation d'un binet à l'autre

### DIFF
--- a/htdocs/beta/view/layout/sidebar.php
+++ b/htdocs/beta/view/layout/sidebar.php
@@ -10,7 +10,12 @@
   						$term_admin = select_term_binet($term_admin["id"], array("id","binet","term"))
   						?>
   						<li>
-  							<?php echo link_to(path("", "binet", binet_term_id($term_admin["binet"], $term_admin["term"])), pretty_binet_term($term_admin["id"], false)); ?>
+  							<?php
+                $link = in_array($_GET["controller"], array("budget", "operation", "validation", "request")) ?
+                  path("", $_GET["controller"], "", binet_prefix($term_admin["binet"], $term_admin["term"])) :
+                  path("", "binet", binet_term_id($term_admin["binet"], $term_admin["term"]));
+                echo link_to($link, pretty_binet_term($term_admin["id"], false));
+                ?>
   						</li>
   						<?php
 						}

--- a/htdocs/beta/view/layout/sidebar.php
+++ b/htdocs/beta/view/layout/sidebar.php
@@ -31,7 +31,7 @@
         );
       }
       $number_pending_validations = count_pending_validations($binet, $term);
-      if (has_editing_rights($binet, $term)) {
+      if (has_editing_rights($binet, $term) && current_term($binet) == $term) {
         echo li_link(
           link_to(
             path("", "validation", "", binet_prefix($binet, $term)),


### PR DESCRIPTION
On peut merger

Petite amélioration de navigation : quand on passe d’un binet à l’autre avec la sidebar, on reste sur le même controlleur.
Si vous n’êtes pas d’accord avec cette amélioration, on est pas obligés de merger.

corrige également un petit bug : l'onglet validation ne doit apparaitre que pour le mandat courant d'un binet.