### PR TITLE
Aide subventions subventionneur

### DIFF
--- a/htdocs/beta/view/help/binet/wave/index.php
+++ b/htdocs/beta/view/help/binet/wave/index.php
@@ -1,5 +1,5 @@
-<h1>Les publications des subventions</h1>
-    <p>Sur cette page, tu peux voir toutes les vagues de subventions depuis la création du site, qu'elles soient passées ou en cours.<br>
+<h1>Les publications de tes subventions</h1>
+    <p>Sur cette page, tu peux voir toutes tes vagues de subventions depuis la création du site, qu'elles soient passées ou en cours.<br>
 
     Les états possibles de celles-ci sont :
 			<ul>
@@ -12,7 +12,6 @@
     Les deux dates indiquées sont celles de clôture de dépôt de demandes et la date limite d’utilisation des subventions.<br>
 
 
-    En cliquant sur une vague en particulier, tu peux voir les montants attribués et les détails pour chaque binet par poste de dépense.<br>
+    En cliquant sur une vague en particulier, tu peux modifier les caractéristiques de la vague : dates ...<br>
 
-    	Tu peux faire tes demandes de subventions en cliquant sur le bouton qui apparait à la droite d'une vague ouverte, et en sélectionnant ensuite ton binet.
 		</p>


### PR DESCRIPTION
J’avais oublié ce texte d’aide, désolé de ne pas l’avoir intégré à la dernière PR. J’ai ouvert une branche qu’il faut supprimer : subventions-help-text (j’avais oublié de synchroniser master).