### PR TITLE
Bug corrections

### DIFF
--- a/htdocs/beta/controller/binet/operation.php
+++ b/htdocs/beta/controller/binet/operation.php
@@ -28,7 +28,7 @@
   }
 
   function check_is_editable_operation() {
-    header_if(is_editable_operation($GLOBALS["operation"]["id"]), 403);
+    header_if(!is_editable_operation($GLOBALS["operation"]["id"]), 403);
   }
 
   before_action("check_csrf_get", array("delete"));

--- a/htdocs/beta/controller/binet/validation.php
+++ b/htdocs/beta/controller/binet/validation.php
@@ -1,6 +1,6 @@
 <?php
 
-  before_action("member_binet_current_term", array("index"));
+  before_action("check_editing_rights", array("index"));
 
   switch ($_GET["action"]) {
 

--- a/htdocs/beta/model/operation.php
+++ b/htdocs/beta/model/operation.php
@@ -18,7 +18,7 @@
   function select_operation($operation, $fields = array()) {
     $present_virtual_fields = array_intersect($fields, array("state", "needs_validation"));
     if (!is_empty($present_virtual_fields)) {
-      $fields = array_unique(array_merge(array("binet_validation_by", "kes_validation_by", "id", "needs_validation"), $fields));
+      $fields = array_unique(array_merge(array("kes_validation_by", "id", "needs_validation"), $fields));
     }
     $operation = select_entry(
       "operation",
@@ -41,10 +41,11 @@
       }
     }
     if (in_array("state", $fields)) {
+      $budgets = select_budgets_operation($operation["id"]);
       $operation["state"] =
         isset($operation["kes_validation_by"]) ?
           "validated" :
-          (!isset($operation["binet_validation_by"]) ?
+          (is_empty($budgets) ?
             "suggested" :
             ($operation["needs_validation"] ?
               "waiting_validation" :

--- a/htdocs/beta/view/layout/sidebar.php
+++ b/htdocs/beta/view/layout/sidebar.php
@@ -31,7 +31,7 @@
         );
       }
       $number_pending_validations = count_pending_validations($binet, $term);
-      if (has_editing_rights($binet, $term) && current_term($binet) == $term) {
+      if (has_editing_rights($binet, $term)) {
         echo li_link(
           link_to(
             path("", "validation", "", binet_prefix($binet, $term)),

--- a/htdocs/beta/view/layout/sidebar.php
+++ b/htdocs/beta/view/layout/sidebar.php
@@ -45,7 +45,7 @@
         $_GET["controller"] == "request"
       );
       // If subsidy provider
-      $sidebar_waves = select_waves(array("binet" => $binet, "term" => $term));
+      $sidebar_waves = array_merge(select_waves(array("binet" => $binet, "term" => $term)), select_waves(array("binet" => $binet, "term" => $term, "state" => "rough_draft")));
       if (!is_empty($sidebar_waves)) {
         ?>
         <li class="divider"></li>


### PR DESCRIPTION
On peut merger

permet de : 
* modifier à nouveau une opération
* avoir les validations dans la sidebar du mandat suivant
* qu'une opération que l'on a attribué au budget, puis dont on a changé le montant, sans l'attribuer à nouveau au budget, apparaisse à nouveau dans les validations
* avoir les vagues de subventions dans la sidebar, même s'il n'y a que des brouillons.

Tout ça en 7 lignes de code.