### PR TITLE
added development to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.project
 
 htdocs/config/production.php
+htdocs/config/development.php
 
 htdocs/-FProjet
 

--- a/htdocs/config/example.php
+++ b/htdocs/config/example.php
@@ -1,0 +1,16 @@
+<?php
+
+  define("WEBMASTER_EMAIL", $_ENV["webmaster_email"]);
+  define("STATE", "development");
+
+  // when changing these values, run localhost/url_rewriting.php to rewrite .htaccess file.
+  define("URL_REWRITE", true); // set to false if you don't want pretty urls.
+  define("ROOT_PATH", ""); // set to "" to remove root_path
+
+  define("DATABASE_USERNAME", "root");
+  define("DATABASE_PASSWORD", "root");
+  define("DATABASE_NAME", "balise");
+  define("DATABASE_HOST", "localhost");
+  define("DATABASE_PORT", "8889");
+  define("FRANKIZ_AUTH_KEY", "A4d!fgr6?45GF8"); // This value allows to make requests for http://localhost:3000/home/login
+  define("REAL_FRANKIZ_CONNECTION", false);

--- a/htdocs/global/initialisation.php
+++ b/htdocs/global/initialisation.php
@@ -1,6 +1,6 @@
 <?php
 
-  if ($_SERVER["HTTP_HOST"] != "balise.bin") {
+  if ($_SERVER["HTTP_HOST"] == "localhost:3000") {
     include "config/development.php";
   } else {
     include "config/production.php";

--- a/htdocs/global/initialisation.php
+++ b/htdocs/global/initialisation.php
@@ -1,6 +1,6 @@
 <?php
 
-  if (isset($_ENV["state"]) && $_ENV["state"] == "development") {
+  if ($_SERVER["HTTP_HOST"] != "balise.bin") {
     include "config/development.php";
   } else {
     include "config/production.php";


### PR DESCRIPTION
On peut merger

(J'espère que cette PR va raviver une flamme qui est en train de s'éteindre plus vite que prévu ...)
Ajoute la configuration de développement au gitignore, comme ça chacun peut avoir son fichier de développement. Du coup on laisse quand même une version d'exemple pour que les gens s'y retrouvent.
@AlexandreGuinaudeau ça te permettra de faire tourner le site en local :) Et @victornicolet et @Newbienathou, il faudra que votre fichier de configuration s'appelle development.php à présent (il faudra que vous alliez le modifier vous même. Je vous conseille de faire simplement une copie, comme ça vous n'aurez pas besoin de merger cette branche dans votre branche déjà créées).